### PR TITLE
Set up self-contained executable

### DIFF
--- a/src/OpenLaMulana.csproj
+++ b/src/OpenLaMulana.csproj
@@ -3,6 +3,9 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <RollForward>Major</RollForward>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>


### PR DESCRIPTION
Allows publishing a self-contained executable.
While developing, you'd want to set the RuntimeIdentifier to the specific one for your OS (linux-x64, mac-x64, win-x64 etc).

To publish a build using this, run
`dotnet publish -r $TARGET`
where $TARGET is the aforementioned RuntimeIdentifier.

Worth mentioning perhaps is that certain APIs will not be available this way. So far it seems to work, but it's something to be mindful of in the future, a list of those APIs can be found [here](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility)